### PR TITLE
feat: add smart import for meds and indexes

### DIFF
--- a/app/sections/medications/page.tsx
+++ b/app/sections/medications/page.tsx
@@ -1,16 +1,27 @@
 'use client'
+import { useState } from 'react'
 import TwoCol from '@/components/TwoCol'
 import InfoSidebar from '@/components/InfoSidebar'
-import { usePacket } from '@/lib/store'
+import SmartImportMeds from '@/components/SmartImportMeds'
+import { usePacket, saveToLocal, type MedRow } from '@/lib/store'
 
 export default function Page() {
   const store = usePacket()
+  const [open, setOpen] = useState(false)
+
+  function apply(row: MedRow){
+    if (row.stop) store.set('medsPast', [...store.medsPast, row])
+    else store.set('medsCurrent', [...store.medsCurrent, row])
+    saveToLocal({} as any)
+  }
+
   return (
     <main className="grid gap-6">
       <TwoCol>
         <div>
           <h2 className="text-lg font-semibold">Section 7 — Medications</h2>
           <p className="mt-3 text-sm text-[color:var(--muted)]">Use the Wizard to add current and past medications.</p>
+          <button className="btn mt-4" onClick={()=>setOpen(true)}>Smart Import</button>
         </div>
         <InfoSidebar title="What to include for Jay — Medications">
           <ul className="list-disc pl-5 text-sm">
@@ -20,6 +31,7 @@ export default function Page() {
           </ul>
         </InfoSidebar>
       </TwoCol>
+      <SmartImportMeds open={open} onClose={()=>setOpen(false)} onApply={apply} />
     </main>
   )
 }

--- a/app/sections/records/page.tsx
+++ b/app/sections/records/page.tsx
@@ -5,9 +5,11 @@ import { generateRecordsCoverDoc } from '@/lib/docgen'
 import TwoCol from '@/components/TwoCol'
 import InfoSidebar from '@/components/InfoSidebar'
 import Tooltip from '@/components/Tooltip'
+import SmartImportDialog from '@/components/SmartImportDialog'
 export default function RecordsPage(){
   const store = usePacket()
   const [rows, setRows] = useState<RecordsIndexRow[]>(store.recordsIndex||[])
+  const [open, setOpen] = useState(false)
   useEffect(()=>{
     const loaded = loadFromLocal()
     if (loaded.recordsIndex) setRows(loaded.recordsIndex as any)
@@ -18,10 +20,18 @@ export default function RecordsPage(){
 
   const left = (
     <main className="card">
+      <div className="flex justify-end mb-2">
+        <button className="btn" onClick={()=>setOpen(true)}>Smart Import</button>
+      </div>
       <IndexTable rows={rows} onChange={setRows} />
       <div className="pt-4">
         <button className="btn btn-primary" onClick={()=>generateRecordsCoverDoc(store)}>Export Cover Sheet (DOCX)</button>
       </div>
+      <SmartImportDialog
+        open={open}
+        onClose={()=>setOpen(false)}
+        onApply={r=>setRows(prev=>prev.map(row=>row.category===r.category?{...row, filename:r.filename, dateRange:r.dateRange}:row))}
+      />
     </main>
   )
 

--- a/app/sections/tests/page.tsx
+++ b/app/sections/tests/page.tsx
@@ -5,9 +5,11 @@ import { generateTestsCoverDoc } from '@/lib/docgen'
 import TwoCol from '@/components/TwoCol'
 import InfoSidebar from '@/components/InfoSidebar'
 import Tooltip from '@/components/Tooltip'
+import SmartImportDialog from '@/components/SmartImportDialog'
 export default function TestsPage(){
   const store = usePacket()
   const [rows, setRows] = useState<TestsIndexRow[]>(store.testsIndex||[])
+  const [open, setOpen] = useState(false)
   useEffect(()=>{
     const loaded = loadFromLocal()
     if (loaded.testsIndex) setRows(loaded.testsIndex as any)
@@ -18,10 +20,18 @@ export default function TestsPage(){
 
   const left = (
     <main className="card">
+      <div className="flex justify-end mb-2">
+        <button className="btn" onClick={()=>setOpen(true)}>Smart Import</button>
+      </div>
       <IndexTable rows={rows} onChange={setRows} />
       <div className="pt-4">
         <button className="btn btn-primary" onClick={()=>generateTestsCoverDoc(store)}>Export Cover Sheet (DOCX)</button>
       </div>
+      <SmartImportDialog
+        open={open}
+        onClose={()=>setOpen(false)}
+        onApply={r=>setRows(prev=>prev.map(row=>row.category===r.category?{...row, filename:r.filename, dateRange:r.dateRange}:row))}
+      />
     </main>
   )
 

--- a/components/SmartImportMeds.tsx
+++ b/components/SmartImportMeds.tsx
@@ -1,0 +1,85 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { extractTextFromPDF, extractTextFromImage, parseMedication } from '@/lib/extract'
+import type { MedRow } from '@/lib/store'
+
+export default function SmartImportMeds({open,onClose,onApply}:{open:boolean; onClose:()=>void; onApply:(row:MedRow)=>void}){
+  const [files, setFiles] = useState<File[]>([])
+  const [idx, setIdx] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string>('')
+  const [raw, setRaw] = useState<string>('')
+  const [suggest, setSuggest] = useState<MedRow|null>(null)
+
+  useEffect(()=>{ if(!open){ setFiles([]); setIdx(0); setBusy(false); setError(''); setRaw(''); setSuggest(null) } },[open])
+  if(!open) return null
+
+  const current = files[idx]
+  const hasMore = idx < files.length - 1
+
+  async function handleExtract(){
+    if(!current) return
+    setBusy(true); setError(''); setRaw(''); setSuggest(null)
+    try{
+      let text = ''
+      if(current.type === 'application/pdf' || current.name.toLowerCase().endsWith('.pdf')) text = await extractTextFromPDF(current)
+      else if(current.type.startsWith('image/')) text = await extractTextFromImage(current)
+      else throw new Error('Please upload a PDF or an image file.')
+      setRaw(text)
+      setSuggest(parseMedication(text))
+    }catch(e:any){ setError(e?.message||'Could not read the file.') }
+    finally{ setBusy(false) }
+  }
+
+  function applyAndNext(){ if(suggest) onApply(suggest); if(hasMore){ setIdx(i=>i+1); setSuggest(null); setRaw(''); setError('') } else onClose() }
+  function applyAndDone(){ if(suggest) onApply(suggest); onClose() }
+  function skip(){ if(hasMore){ setIdx(i=>i+1); setSuggest(null); setRaw(''); setError('') } else onClose() }
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40" role="dialog" aria-modal="true" aria-label="Smart Import — Meds">
+      <div className="card max-w-2xl w-full">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-lg font-semibold">Smart Import — Medications</h3>
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+        <p className="text-xs text-[color:var(--muted)] mb-3">Files are processed locally. Review and edit before applying.</p>
+
+        <div className="grid gap-3">
+          <div className="grid sm:grid-cols-3 gap-2">
+            <div className="sm:col-span-2"><input type="file" multiple accept="application/pdf,image/*" onChange={e=>{const list=Array.from(e.target.files||[]); setFiles(list); setIdx(0); setSuggest(null); setRaw(''); setError('')}} /></div>
+            <div className="text-sm text-[color:var(--muted)]">{files.length>0 ? <span>File {idx+1} of {files.length}{current?`: ${current.name}`:''}</span> : <span>No files selected</span>}</div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button className="btn btn-primary" onClick={handleExtract} disabled={!current||busy}>{busy?'Reading…':'Extract text'}</button>
+            {suggest && <button className="btn" onClick={applyAndNext}>Apply & add another</button>}
+            {suggest && <button className="btn" onClick={applyAndDone}>Apply & done</button>}
+            {files.length>0 && <button className="btn" onClick={skip} disabled={!hasMore && !suggest}>Skip</button>}
+          </div>
+
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          {suggest && (
+            <div className="grid gap-2">
+              <h4 className="text-base font-semibold mt-2">Suggested fields</h4>
+              <div className="grid sm:grid-cols-2 gap-2">
+                <div><label className="label">Name</label><input className="input" value={suggest.name||''} onChange={e=>setSuggest({...suggest!, name:e.target.value})} /></div>
+                <div><label className="label">Dosage & Freq</label><input className="input" value={suggest.dose||''} onChange={e=>setSuggest({...suggest!, dose:e.target.value})} /></div>
+                <div><label className="label">Start</label><input className="input" value={suggest.start||''} onChange={e=>setSuggest({...suggest!, start:e.target.value})} /></div>
+                <div><label className="label">Stop</label><input className="input" value={suggest.stop||''} onChange={e=>setSuggest({...suggest!, stop:e.target.value})} /></div>
+                <div><label className="label">Purpose</label><input className="input" value={suggest.purpose||''} onChange={e=>setSuggest({...suggest!, purpose:e.target.value})} /></div>
+                <div><label className="label">Response</label><input className="input" value={suggest.response||''} onChange={e=>setSuggest({...suggest!, response:e.target.value})} /></div>
+                <div className="sm:col-span-2"><label className="label">Side Effects / Reason Stopped</label><input className="input" value={suggest.sidefx||''} onChange={e=>setSuggest({...suggest!, sidefx:e.target.value})} /></div>
+              </div>
+              {raw && (
+                <details className="mt-2">
+                  <summary className="cursor-pointer">Show extracted text</summary>
+                  <pre className="text-xs whitespace-pre-wrap mt-2">{raw.slice(0,12000)}</pre>
+                </details>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/Wizard.tsx
+++ b/components/Wizard.tsx
@@ -10,8 +10,6 @@ import InfoSidebar from '@/components/InfoSidebar'
 import StatusBadge from '@/components/StatusBadge'
 import { useToast } from '@/components/Toast'
 import { useDisplayName } from '@/lib/store'
-import { downloadAllZip } from '@/lib/zip'
-import { Archive} from 'lucide-react'
 
 import { CalendarRange, ClipboardList, FileDown, FileSpreadsheet, FileText, FlaskConical, FolderOpenDot, FolderOutput, NotebookPen, Pill, TestTubes, LineChart as TimelineIcon, Users} from 'lucide-react'
 

--- a/lib/docgen.ts
+++ b/lib/docgen.ts
@@ -146,18 +146,21 @@ export async function buildTestsCoverDoc(state: PacketState){
 
 export async function buildProviderTrackerDoc(state: PacketState){
   const docx = await loadDocx()
-  const { Document, Packer } = docx
+  const { Document, Packer, Table, TableRow, TableCell, WidthType } = docx
   const { titlePara, p } = helpers(docx)
-  const prov = state.provider
-  const doc = new Document({ sections: [{ children: [
-    titlePara('Section 3 — Provider Tracker'),
-    p(`Doctor: ${prov.doctorName || ''}`),
-    p(`Specialty: ${prov.specialty || ''}`),
-    p(`Email: ${prov.email || ''}`),
-    p(`Due Date: ${prov.dueDate || ''}`),
-    p(`Status: ${prov.status || ''}`),
-    p(`Notes: ${prov.notes || ''}`),
-  ] }]})
+  const prov = state.provider || {} as PacketState['provider']
+  const table = new Table({
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    rows: [
+      new TableRow({ children: [ new TableCell({ children:[p('Doctor')] }), new TableCell({ children:[p(prov.doctorName || '')] }) ] }),
+      new TableRow({ children: [ new TableCell({ children:[p('Specialty')] }), new TableCell({ children:[p(prov.specialty || '')] }) ] }),
+      new TableRow({ children: [ new TableCell({ children:[p('Email')] }), new TableCell({ children:[p(prov.email || '')] }) ] }),
+      new TableRow({ children: [ new TableCell({ children:[p('Due Date')] }), new TableCell({ children:[p(prov.dueDate || '')] }) ] }),
+      new TableRow({ children: [ new TableCell({ children:[p('Status')] }), new TableCell({ children:[p(prov.status || '')] }) ] }),
+      new TableRow({ children: [ new TableCell({ children:[p('Notes')] }), new TableCell({ children:[p(prov.notes || '')] }) ] }),
+    ]
+  })
+  const doc = new Document({ sections: [{ children: [ titlePara('Section 3 — Provider Tracker'), table ] }] })
   return { doc, async createBlob(){ return await Packer.toBlob(doc) } }
 }
 


### PR DESCRIPTION
## Summary
- add SmartImportMeds component for extracting medication details from PDFs/images
- hook up smart import dialog to records and tests sections
- generate provider tracker document and clean up wizard imports

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a0bc8170a88332a1efaf9598457fec